### PR TITLE
Change managerIdentifier to match classname

### DIFF
--- a/xDripClient/xDripClientManager.swift
+++ b/xDripClient/xDripClientManager.swift
@@ -42,7 +42,7 @@ public class xDripClientManager: CGMManager {
     }
     
     
-    public static var managerIdentifier = "xDripClient"
+    public static var managerIdentifier = "xDripClientManager"
 
     public init() {
         client = xDripClient()


### PR DESCRIPTION
This fix as proposed by dabear allows the CGMManager preference to be stored between Loop runs.